### PR TITLE
Make scripts executable

### DIFF
--- a/mk
+++ b/mk
@@ -1,4 +1,6 @@
-rm ./src/release/cuda_ed25519_vanity 
-rm ./src/release/ecc_scan.o 
-#export PATH=/usr/local/cuda/bin:$PATH
-make -j$(nproc)
+#!/bin/bash
+
+rm ./src/release/cuda_ed25519_vanity;
+rm ./src/release/ecc_scan.o;
+#export PATH=/usr/local/cuda/bin:$PATH;
+make -j;

--- a/run
+++ b/run
@@ -1,1 +1,3 @@
-LD_LIBRARY_PATH=./src/release ./src/release/cuda_ed25519_vanity
+#!/bin/bash
+
+LD_LIBRARY_PATH=./src/release ./src/release/cuda_ed25519_vanity;


### PR DESCRIPTION
Also marked the scripts as bash scripts.

Also, the default behavior of make -j is identical to make -j$(nproc), so the latter is unnecessary